### PR TITLE
test: subscription smoke tests + deploy policy docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@ Wijzigingen in andere repos moeten hier vaak worden gevalideerd.
 2. `../pagayo-vault/PAGAYO-NIVEAU.md`
 3. `./README.md`
 
+## Deploy Policy (Hard)
+- NOOIT direct naar `main` pushen.
+- ALTIJD eerst werken op `feature/batch-staging-YYYYMMDD`.
+- ALTIJD eerst committen en pushen naar die staging-branch.
+- Voor deploys: ALTIJD starten met `workflow_dispatch` en `deploy_mode=staging-only` waar ondersteund.
+- Productie (`main` merge of `deploy_mode=full/production-only`) ALLEEN na expliciete goedkeuring van Sjoerd in dezelfde thread.
+- Bij twijfel: stop en vraag Sjoerd.
+
 ## Harde grenzen
 - Geen `.skip` of uitgestelde tests voor productie-kritische paden.
 - Contracttests moeten breaking changes snel zichtbaar maken.

--- a/tests/smoke/storefront.test.ts
+++ b/tests/smoke/storefront.test.ts
@@ -2307,6 +2307,31 @@ describe("Storefront Service - Smoke Tests", () => {
       expect(response.status).toBe(401);
     });
 
+    it("POST /api/admin/subscriptions/:id/resend-emails returns auth error without session", async () => {
+      const response = await fetch(
+        `${STOREFRONT_URL}/api/admin/subscriptions/999/resend-emails`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            resendWelcome: true,
+            resendMemberInviteIds: [],
+            idempotencyKey: "smoke-test-12345678",
+          }),
+        },
+      );
+
+      if (skipIfNoTenant(response, "admin-subscription-resend-emails-no-auth"))
+        return;
+
+      log(
+        "admin-subscription-resend-emails-no-auth",
+        response.status < 500 ? "PASS" : "FAIL",
+        `Status: ${response.status}`,
+      );
+      expect(response.status).toBeLessThan(500);
+    });
+
     it("GET /api/internal/active-tenants requires secret", async () => {
       const response = await fetch(
         `${STOREFRONT_URL}/api/internal/active-tenants`,


### PR DESCRIPTION
## Wijzigingen

### test: voeg storefront smoke check voor subscriptions toe
- Nieuwe smoke tests voor subscription functionaliteit

### docs: maak staging-first deploy policy expliciet
- Deploy policy documentatie verduidelijkt

---
**Branch:** feature/batch-staging-20260401 (2 commits ahead, 0 behind main)