### PR TITLE
Staging: onderhoud tests voor webhook/service binding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@ Wijzigingen in andere repos moeten hier vaak worden gevalideerd.
 2. `../pagayo-vault/PAGAYO-NIVEAU.md`
 3. `./README.md`
 
+## Deploy Policy (Hard)
+- NOOIT direct naar `main` pushen.
+- ALTIJD eerst werken op `feature/batch-staging-YYYYMMDD`.
+- ALTIJD eerst committen en pushen naar die staging-branch.
+- Voor deploys: ALTIJD starten met `workflow_dispatch` en `deploy_mode=staging-only` waar ondersteund.
+- Productie (`main` merge of `deploy_mode=full/production-only`) ALLEEN na expliciete goedkeuring van Sjoerd in dezelfde thread.
+- Bij twijfel: stop en vraag Sjoerd.
+
 ## Harde grenzen
 - Geen `.skip` of uitgestelde tests voor productie-kritische paden.
 - Contracttests moeten breaking changes snel zichtbaar maken.

--- a/tests/integration/cross-worker-rpc.test.ts
+++ b/tests/integration/cross-worker-rpc.test.ts
@@ -130,6 +130,20 @@ describe("Service Binding Configuration", () => {
       expect(apiStackBindings?.length ?? 0).toBeGreaterThanOrEqual(2);
     });
   });
+
+  describe("API-Stack wrangler.toml service bindings", () => {
+    const wrangler = readRepoFile("pagayo-api-stack", "wrangler.toml");
+
+    it("has STOREFRONT service binding", () => {
+      expect(wrangler).toContain('binding = "STOREFRONT"');
+      expect(wrangler).toContain('service = "pagayo-storefront"');
+    });
+
+    it("has STOREFRONT binding in staging and production", () => {
+      const storefrontBindings = wrangler.match(/binding\s*=\s*"STOREFRONT"/g);
+      expect(storefrontBindings?.length ?? 0).toBeGreaterThanOrEqual(2);
+    });
+  });
 });
 
 // ===========================================
@@ -216,6 +230,30 @@ describe("Storefront → API-Stack (Email)", () => {
     expect(
       callsApiStackMethod,
       "Storefront should call API Stack email methods on API_STACK binding",
+    ).toBe(true);
+  });
+});
+
+describe("API-Stack → Storefront (Payment Status Forwarding)", () => {
+  it("api-stack uses STOREFRONT binding in source code", () => {
+    const usages = findBindingUsages("pagayo-api-stack", "STOREFRONT");
+    expect(
+      usages.length,
+      "STOREFRONT binding should be referenced in api-stack source code",
+    ).toBeGreaterThan(0);
+  });
+
+  it("api-stack forwards payment status via STOREFRONT binding", () => {
+    const usages = findBindingUsages("pagayo-api-stack", "STOREFRONT");
+    const allLines = usages.flatMap((u) => u.lines);
+    const lineText = allLines.join("\n");
+
+    const callsStorefront =
+      lineText.includes("STOREFRONT.fetch") || lineText.includes("forward");
+
+    expect(
+      callsStorefront,
+      "API Stack should forward payment status via STOREFRONT service binding",
     ).toBe(true);
   });
 });
@@ -350,5 +388,10 @@ describe("Worker Binding Type Definitions", () => {
       found,
       "Storefront should have EDGE and API_STACK in type definitions",
     ).toBe(true);
+  });
+
+  it("api-stack has STOREFRONT in its type definitions", () => {
+    const typesFile = readRepoFile("pagayo-api-stack", "src/workers/types.ts");
+    expect(typesFile).toContain("STOREFRONT");
   });
 });

--- a/tests/smoke/storefront.test.ts
+++ b/tests/smoke/storefront.test.ts
@@ -2437,6 +2437,25 @@ describe("Storefront Service - Smoke Tests", () => {
   });
 
   describe("Stripe PaymentIntent API", () => {
+    it("POST /api/payments/stripe/webhook without signature returns 400", async () => {
+      const response = await fetch(
+        `${STOREFRONT_URL}/api/payments/stripe/webhook`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: "evt_smoke_test", type: "payment_intent.succeeded" }),
+        },
+      );
+
+      log(
+        "stripe-storefront-webhook-missing-signature",
+        response.status === 400 ? "PASS" : "FAIL",
+        `Status: ${response.status}`,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
     it("POST /api/payments/stripe/payment-intent without orderId returns 400 or 403", async () => {
       const response = await fetch(
         `${STOREFRONT_URL}/api/payments/stripe/payment-intent`,

--- a/tests/smoke/storefront.test.ts
+++ b/tests/smoke/storefront.test.ts
@@ -2307,6 +2307,31 @@ describe("Storefront Service - Smoke Tests", () => {
       expect(response.status).toBe(401);
     });
 
+    it("POST /api/admin/subscriptions/:id/resend-emails returns auth error without session", async () => {
+      const response = await fetch(
+        `${STOREFRONT_URL}/api/admin/subscriptions/999/resend-emails`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            resendWelcome: true,
+            resendMemberInviteIds: [],
+            idempotencyKey: "smoke-test-12345678",
+          }),
+        },
+      );
+
+      if (skipIfNoTenant(response, "admin-subscription-resend-emails-no-auth"))
+        return;
+
+      log(
+        "admin-subscription-resend-emails-no-auth",
+        response.status < 500 ? "PASS" : "FAIL",
+        `Status: ${response.status}`,
+      );
+      expect(response.status).toBeLessThan(500);
+    });
+
     it("GET /api/internal/active-tenants requires secret", async () => {
       const response = await fetch(
         `${STOREFRONT_URL}/api/internal/active-tenants`,


### PR DESCRIPTION
## Samenvatting\n- Voeg storefront webhook smoke-contract toe (missing signature => 400)\n- Breid cross-worker RPC integratiechecks uit met api-stack -> storefront binding coverage\n\n## Validatie\n- vitest integration/smoke