### PR TITLE
chore: pin packageManager to npm@11.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  }
+  },
+  "packageManager": "npm@11.11.0"
 }


### PR DESCRIPTION
Pint npm-versie via packageManager veld om drift tussen dev en CI te voorkomen (ref: npm-lockfile-drift-npm11-peer-metadata). Fase F van deploy-hardening batch. Geen lockfile/npm install wijzigingen.