### PR TITLE
fix(releases): update manifest via PR flow

### DIFF
--- a/.github/workflows/update-release-manifest.yml
+++ b/.github/workflows/update-release-manifest.yml
@@ -2,8 +2,8 @@
 # Update Release Manifest
 # -----------------------------------------------------------------------------
 # Wordt getriggerd door staging-deploy workflows van consumer-repo's nadat hun
-# smoke tests groen zijn. Werkt releases/current.json bij en commit direct naar
-# main.
+# smoke tests groen zijn. Werkt releases/current.json bij via een branch + PR
+# zodat branch protection op main gerespecteerd blijft.
 #
 # Consumers triggeren via:
 #   gh workflow run update-release-manifest.yml \
@@ -33,6 +33,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:
@@ -61,8 +62,61 @@ jobs:
           fi
 
       - name: Run update script
+        id: prepare
         env:
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
           chmod +x scripts/update-release-manifest.sh
-          scripts/update-release-manifest.sh "${{ inputs.repo }}" "${{ inputs.sha }}"
+          scripts/update-release-manifest.sh "${{ inputs.repo }}" "${{ inputs.sha }}" --write-only
+
+      - name: Create or update manifest PR
+        id: manifest_pr
+        if: steps.prepare.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: |
+            releases/current.json
+          branch: ${{ steps.prepare.outputs.pr_branch }}
+          base: main
+          delete-branch: true
+          commit-message: ${{ steps.prepare.outputs.commit_message }}
+          title: ${{ steps.prepare.outputs.pr_title }}
+          body: |
+            ## Release manifest update
+
+            - Repo: `${{ inputs.repo }}`
+            - Verified staging SHA: `${{ inputs.sha }}`
+            - Triggered by: `${{ github.actor }}`
+
+            Deze PR is automatisch aangemaakt door `update-release-manifest.yml`.
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+
+      - name: Report PR status
+        if: steps.prepare.outputs.changed == 'true'
+        run: |
+          if [[ -z "${{ steps.manifest_pr.outputs.pull-request-number }}" ]]; then
+            echo "::error::Manifest wijzigde, maar er is geen pull request aangemaakt of bijgewerkt."
+            exit 1
+          fi
+
+          if [[ "${{ steps.manifest_pr.outputs.pull-request-operation }}" == "created" ]]; then
+            echo "✅ Pull request aangemaakt: #${{ steps.manifest_pr.outputs.pull-request-number }}"
+          elif [[ "${{ steps.manifest_pr.outputs.pull-request-operation }}" == "updated" ]]; then
+            echo "ℹ️  Bestaande pull request bijgewerkt: #${{ steps.manifest_pr.outputs.pull-request-number }}"
+          else
+            echo "ℹ️  Pull request status: ${{ steps.manifest_pr.outputs.pull-request-operation }} (#${{ steps.manifest_pr.outputs.pull-request-number }})"
+          fi
+
+      - name: Enable auto-merge
+        if: steps.prepare.outputs.changed == 'true' && steps.manifest_pr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.manifest_pr.outputs.pull-request-number }}
+          merge-method: squash
+
+      - name: No manifest change
+        if: steps.prepare.outputs.changed != 'true'
+        run: echo "ℹ️  Geen manifest-wijziging nodig; er is geen PR geopend."

--- a/RUNBOOK-release-manifest.md
+++ b/RUNBOOK-release-manifest.md
@@ -7,15 +7,15 @@ gereleased is via staging.
 ## 1. Concept
 
 | Ding | Betekenis |
-|------|-----------|
+| ---- | --------- |
 | `releases/current.json` | SSOT voor laatst-verified staging-SHA per Pagayo-repo |
-| `scripts/update-release-manifest.sh` | Idempotente updater van de JSON + commit + push |
+| `scripts/update-release-manifest.sh` | Idempotente updater van de JSON zonder git side effects |
 | `.github/workflows/update-release-manifest.yml` | Dispatch-target waar consumer-repo's naar schrijven na groene staging-smoke |
 | `.github/workflows/reusable-preprod-guard.yml` | Reusable workflow die caller-SHA vergelijkt met het manifest |
 
 ## 2. Flow
 
-```
+```text
 [consumer repo]                       [pagayo-maintenance]
   staging deploy + smoke (success)
          │
@@ -28,7 +28,7 @@ gereleased is via staging.
          │                     scripts/update-release-manifest.sh
          │                                   │
          │                                   ▼
-         │                         commit + push → main
+         │                branch + PR + auto-merge → main
          │
          ▼
   productie-deploy (workflow_dispatch, mode=full of production-only)
@@ -102,7 +102,7 @@ cd pagayo-maintenance
 scripts/update-release-manifest.sh pagayo-storefront $(printf '%040d' 1) --dry-run
 ```
 
-Dit toont de te schrijven entry zonder commit/push.
+Dit toont de te schrijven entry zonder bestandsschrijfactie of git side effects.
 
 ## 7. Versie-bump van het manifest
 

--- a/releases/README.md
+++ b/releases/README.md
@@ -28,7 +28,7 @@ Productie-deploys valideren de deploy-SHA tegen dit manifest via de `reusable-pr
 
 1. Repo's staging-deploy job draait smoke tests.
 2. Bij success triggert de job (via `gh workflow run`) de `update-release-manifest.yml` workflow in **pagayo-maintenance** met `repo` + `sha`.
-3. Die workflow draait `scripts/update-release-manifest.sh` en commit de update direct naar `main`.
+3. Die workflow draait `scripts/update-release-manifest.sh`, opent of ververst een manifest-PR en zet auto-merge aan zodat `main` alleen via branch protection wordt bijgewerkt.
 
 **Handmatige edits zijn verboden** behalve voor rollback/hotfix (zie `RUNBOOK-release-manifest.md`).
 

--- a/scripts/update-release-manifest.sh
+++ b/scripts/update-release-manifest.sh
@@ -8,17 +8,22 @@
 # Lokaal (dry-run):
 #   scripts/update-release-manifest.sh pagayo-storefront abc123... --dry-run
 #
-# In CI (commit + push direct naar main):
-#   scripts/update-release-manifest.sh pagayo-storefront abc123...
+# Lokaal of in CI (alleen bestand bijwerken, geen git side effects):
+#   scripts/update-release-manifest.sh pagayo-storefront abc123... --write-only
 # =============================================================================
 set -euo pipefail
 
 REPO="${1:-}"
 SHA="${2:-}"
-MODE="${3:-commit}"
+MODE="${3:---write-only}"
 
 if [[ -z "$REPO" || -z "$SHA" ]]; then
-  echo "Usage: $0 <repo-name> <full-sha> [--dry-run]" >&2
+  echo "Usage: $0 <repo-name> <full-sha> [--dry-run|--write-only]" >&2
+  exit 2
+fi
+
+if [[ "$MODE" != "--dry-run" && "$MODE" != "--write-only" ]]; then
+  echo "::error::Ongeldige mode '$MODE'. Gebruik --dry-run of --write-only." >&2
   exit 2
 fi
 
@@ -49,6 +54,9 @@ fi
 
 NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ACTOR="${GITHUB_ACTOR:-github-actions[bot]}"
+SHORT_SHA="${SHA:0:12}"
+COMMIT_MESSAGE="chore(releases): verify $REPO@$SHORT_SHA in staging"
+PR_BRANCH="automation/release-manifest-$REPO"
 
 TMP="$(mktemp)"
 jq \
@@ -62,27 +70,42 @@ jq \
    | .repos[$repo].verified_at = $now' \
   "$MANIFEST" > "$TMP"
 
-mv "$TMP" "$MANIFEST"
-echo "✅ Manifest updated: $REPO -> $SHA ($NOW)"
+if cmp -s "$TMP" "$MANIFEST"; then
+  rm -f "$TMP"
+  echo "ℹ️  Geen manifest-wijziging nodig: $REPO staat al op $SHA."
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "changed=false"
+      echo "commit_message=$COMMIT_MESSAGE"
+      echo "pr_branch=$PR_BRANCH"
+      echo "pr_title=$COMMIT_MESSAGE"
+    } >> "$GITHUB_OUTPUT"
+  fi
+
+  if [[ "$MODE" == "--dry-run" ]]; then
+    jq --arg repo "$REPO" '.repos[$repo]' "$MANIFEST"
+  fi
+
+  exit 0
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "changed=true"
+    echo "commit_message=$COMMIT_MESSAGE"
+    echo "pr_branch=$PR_BRANCH"
+    echo "pr_title=$COMMIT_MESSAGE"
+  } >> "$GITHUB_OUTPUT"
+fi
 
 if [[ "$MODE" == "--dry-run" ]]; then
-  echo "ℹ️  --dry-run: geen commit/push."
-  jq --arg repo "$REPO" '.repos[$repo]' "$MANIFEST"
+  echo "ℹ️  --dry-run: geen bestandsschrijfactie of git-actie."
+  jq --arg repo "$REPO" '.repos[$repo]' "$TMP"
+  rm -f "$TMP"
   exit 0
 fi
 
-# Commit + push direct naar main (manifest is stabieler dan feature-branch:
-# staat voor "verified in staging", niet voor "work in progress").
-cd "$REPO_ROOT"
-git config user.name  "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-if git diff --quiet -- releases/current.json; then
-  echo "ℹ️  Geen wijzigingen aan manifest (identieke SHA). Skip commit."
-  exit 0
-fi
-
-git add releases/current.json
-git commit -m "chore(releases): verify $REPO@${SHA:0:12} in staging"
-git push origin HEAD:main
-echo "✅ Commit gepusht naar main."
+mv "$TMP" "$MANIFEST"
+echo "✅ Manifest bijgewerkt: $REPO -> $SHA ($NOW)"
+echo "ℹ️  Geen git side effects: open een PR vanaf $PR_BRANCH om deze wijziging naar main te brengen."


### PR DESCRIPTION
## Waarom
De huidige `update-release-manifest` flow probeert rechtstreeks naar protected `main` te pushen. Daardoor faalt de release-manifest update met `GH006`, en blokkeren production promoties op de pre-prod release-manifest guard.

## Wat verandert
- manifest-update workflow respecteert branch protection
- update-script doet geen directe push naar `main` meer
- workflow opent of ververst een PR voor `releases/current.json`
- auto-merge wordt aangezet zodat `main` pas bijgewerkt wordt na succesvolle checks
- documentatie bijgewerkt voor de nieuwe PR-gebaseerde flow

## Impact
Dit herstelt de staging -> production keten voor repos die de release-manifest guard gebruiken, zonder protected-branch regels te omzeilen.
