### PR TITLE
chore(releases): verify pagayo-storefront@46008ca28505 in staging

### DIFF
--- a/releases/current.json
+++ b/releases/current.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "updated_at": "2026-04-24T15:00:22Z",
-  "updated_by": "github-ops-agent",
+  "updated_at": "2026-04-24T15:44:33Z",
+  "updated_by": "github-actions[bot]",
   "repos": {
     "pagayo-storefront": {
-      "staging_sha": "8c60a3774fad9c0c541c8f0a998ad8983217bc17",
-      "verified_at": "2026-04-24T15:00:22Z"
+      "staging_sha": "46008ca285054c435ab0fb5883d8dccb7827211b",
+      "verified_at": "2026-04-24T15:44:33Z"
     },
     "pagayo-api-stack": {
       "staging_sha": null,


### PR DESCRIPTION
## Waarom
Handmatige manifest-update om de storefront `staging_sha` op `main` te zetten na succesvolle staging-validatie, zodat de pre-prod release-manifest guard weer doorlaat.

## Wat verandert
- update van `releases/current.json` voor `pagayo-storefront`
- `staging_sha` naar `46008ca285054c435ab0fb5883d8dccb7827211b`
- timestamps/metadata bijgewerkt

## Opmerking
Deze PR is een eenmalige operationele herstelstap nadat de structurele PR-flow-fix voor manifest-updates al is gemerged.
