### PR TITLE
chore(releases): verify pagayo-storefront@b26d70a2336d in staging

### DIFF
--- a/releases/current.json
+++ b/releases/current.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "updated_at": "2026-04-24T15:44:33Z",
-  "updated_by": "github-actions[bot]",
+  "updated_at": "2026-04-24T17:27:35Z",
+  "updated_by": "Pagayo",
   "repos": {
     "pagayo-storefront": {
-      "staging_sha": "46008ca285054c435ab0fb5883d8dccb7827211b",
-      "verified_at": "2026-04-24T15:44:33Z"
+      "staging_sha": "b26d70a2336d508088143e2ae2e6071f28523771",
+      "verified_at": "2026-04-24T17:27:35Z"
     },
     "pagayo-api-stack": {
       "staging_sha": null,


### PR DESCRIPTION
## Release manifest update
- Repo: `pagayo-storefront`
- Verified staging SHA: `b26d70a2336d508088143e2ae2e6071f28523771`
- Triggered manually after workflow token/permission guard blocked auto-PR creation.