### PR TITLE
fix(ci): negeer untracked files in deployer-preflight CHECK 1

### DIFF
--- a/.github/scripts/deployer-preflight.sh
+++ b/.github/scripts/deployer-preflight.sh
@@ -32,10 +32,12 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "📋 CHECK 1: Uncommitted Changes"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-if [[ -n $(git status --porcelain) ]]; then
+# In CI (GitHub Actions), untracked files zoals .maintenance/ zijn normaal — negeer die.
+# Controleer alleen tracked modified/staged files.
+if [[ -n $(git status --porcelain --untracked-files=no) ]]; then
     echo "⚠️  WAARSCHUWING: Er zijn uncommitted changes!"
     echo ""
-    git status --short
+    git status --short --untracked-files=no
     echo ""
     echo "❌ ACTIE VEREIST: Commit of stash deze changes eerst!"
     UNCOMMITTED=true


### PR DESCRIPTION
## Probleem

De reusable `reusable-deployer-preflight.yml` checkt de pagayo-maintenance repo uit naar `.maintenance/` in de caller workspace. Hierdoor detecteert `deployer-preflight.sh` CHECK 1 dit als 'uncommitted changes' (untracked directory).

## Fix

Gebruik `--untracked-files=no` in CHECK 1 van het script. Zo worden alleen gewijzigde/gestagede tracked files gedetecteerd, niet untracked directories zoals `.maintenance/`.

## Impact

- Fixes alle three repos die de preflight draaien: storefront, api-stack, edge
- Geen gedragswijziging voor lokaal gebruik (lokaal zijn er nooit untracked .maintenance/ directories)
- CHECK 2 (local vs remote sync) blijft ongewijzigd