### PR TITLE
ci: optional PAT merge for release manifest + runbook §9

### DIFF
--- a/.github/workflows/update-release-manifest.yml
+++ b/.github/workflows/update-release-manifest.yml
@@ -3,7 +3,8 @@
 # -----------------------------------------------------------------------------
 # Wordt getriggerd door staging-deploy workflows van consumer-repo's nadat hun
 # smoke tests groen zijn. Werkt releases/current.json bij via een branch + PR
-# zodat branch protection op main gerespecteerd blijft.
+# zodat branch protection op main gerespecteerd blijft. Optioneel: secret
+# RELEASE_MANIFEST_MERGE_PAT voert direct admin-merge uit (zie RUNBOOK §9).
 #
 # Consumers triggeren via:
 #   gh workflow run update-release-manifest.yml \
@@ -109,8 +110,35 @@ jobs:
             echo "ℹ️  Pull request status: ${{ steps.manifest_pr.outputs.pull-request-operation }} (#${{ steps.manifest_pr.outputs.pull-request-number }})"
           fi
 
-      - name: Enable auto-merge
+      # Optioneel: zet repository secret RELEASE_MANIFEST_MERGE_PAT (classic `repo` of
+      # org-admin PAT met merge-rechten) zodat manifest-PR's direct op main komen wanneer
+      # branch rules auto-merge blokkeren (bv. required review zonder bot-bypass).
+      - name: Try immediate merge with bypass PAT
+        id: pat_merge
         if: steps.prepare.outputs.changed == 'true' && steps.manifest_pr.outputs.pull-request-number != ''
+        env:
+          MERGE_PAT: ${{ secrets.RELEASE_MANIFEST_MERGE_PAT }}
+        run: |
+          echo "merged=false" >> "$GITHUB_OUTPUT"
+          if [ -z "${MERGE_PAT:-}" ]; then
+            echo "ℹ️ Geen RELEASE_MANIFEST_MERGE_PAT — alleen auto-merge."
+            exit 0
+          fi
+          PR="${{ steps.manifest_pr.outputs.pull-request-number }}"
+          export GH_TOKEN="$MERGE_PAT"
+          echo "🔀 Probeer PR #$PR te mergen met RELEASE_MANIFEST_MERGE_PAT..."
+          if gh pr merge "$PR" --repo "${{ github.repository }}" --squash --admin; then
+            echo "merged=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Manifest PR #$PR direct gemerged (bypass PAT)."
+          else
+            echo "::warning::PAT-merge mislukt (rechten of PR-status); val terug op auto-merge."
+          fi
+
+      - name: Enable auto-merge
+        if: >-
+          steps.prepare.outputs.changed == 'true' &&
+          steps.manifest_pr.outputs.pull-request-number != '' &&
+          steps.pat_merge.outputs.merged != 'true'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/RUNBOOK-release-manifest.md
+++ b/RUNBOOK-release-manifest.md
@@ -111,3 +111,19 @@ Bij breaking wijzigingen in de structuur van `current.json`:
 1. Bump `version` (bv. `1` → `2`).
 2. Update `scripts/update-release-manifest.sh` + `reusable-preprod-guard.yml` om de nieuwe structuur te begrijpen.
 3. Consumer-workflows blijven compatibel omdat ze alleen `repo`/`sha` inputs sturen.
+
+## 8. Troubleshooting
+
+### 8.1 `gh api` voor `releases/current.json`
+
+De GitHub **Contents API** is een `GET`. Gebruik **`?ref=main` in de URL**, niet `-f ref=main` als form field op `gh api`:
+
+```bash
+gh api 'repos/Pagayo/pagayo-maintenance/contents/releases/current.json?ref=main' --jq .name
+```
+
+### 8.2 “Release manifest is niet op tijd bijgewerkt” terwijl deploy groen is
+
+`update-release-manifest.yml` opent/werkt een **PR** op `pagayo-maintenance` met **auto-merge**. Tot die PR op `main` staat (CI op de PR, branch protection, approvals), blijft `staging_sha` in `current.json` op de oude waarde. Consumer-deploys pollen daarom **lang genoeg** op de nieuwe SHA.
+
+Als dit structureel time-out: manifest-PR sneller mergebaar maken (vereiste checks/reviews) of de poll in de consumer-workflow verder verhogen.

--- a/RUNBOOK-release-manifest.md
+++ b/RUNBOOK-release-manifest.md
@@ -126,4 +126,20 @@ gh api 'repos/Pagayo/pagayo-maintenance/contents/releases/current.json?ref=main'
 
 `update-release-manifest.yml` opent/werkt een **PR** op `pagayo-maintenance` met **auto-merge**. Tot die PR op `main` staat (CI op de PR, branch protection, approvals), blijft `staging_sha` in `current.json` op de oude waarde. Consumer-deploys pollen daarom **lang genoeg** op de nieuwe SHA.
 
-Als dit structureel time-out: manifest-PR sneller mergebaar maken (vereiste checks/reviews) of de poll in de consumer-workflow verder verhogen.
+Als GitHub `mergeStateStatus` **BLOCKED** is (bv. verplichte review zonder bypass voor bots), blijft auto-merge hangen. Oplossingen:
+
+1. **Ruleset / branch protection**: voeg een bypass toe voor `github-actions[bot]` of voor pad `releases/**`, of verlaag vereisten op automation-PR’s.
+2. **Consumer** (`RELEASE_MANIFEST_TOKEN`): als de PAT-eigenaar org/repo-admin is, probeert de storefront/api-stack-workflow na timeout automatisch `gh pr merge --admin` op de open manifest-PR (zelfde token als workflow-dispatch).
+3. Zie **§9** voor optionele `RELEASE_MANIFEST_MERGE_PAT` op **pagayo-maintenance** (merge direct vanuit `update-release-manifest.yml`).
+
+## 9. Optioneel: `RELEASE_MANIFEST_MERGE_PAT` (pagayo-maintenance)
+
+Repository secret **alleen** op `Pagayo/pagayo-maintenance`:
+
+| Secret | Doel |
+| ------ | ---- |
+| `RELEASE_MANIFEST_MERGE_PAT` | Classic PAT met `repo` (of org-admin met merge + bypass), owner met rechten om **protected `main`** te mergen. Wordt gebruikt in `update-release-manifest.yml` om de manifest-PR direct met `--squash --admin` te mergen na aanmaak, vóór/naast auto-merge. |
+
+Zonder deze secret blijft het gedrag: PR + auto-merge (zoals voorheen). Met secret falen deploys niet meer op een oneindig geblokkeerde auto-merge zolang de PAT geldig is.
+
+> Fine-grained PAT: minimaal **Contents** en **Pull requests** op `pagayo-maintenance`; de token-eigenaar moet volgens GitHub-regels admin-merge op `main` mogen doen.


### PR DESCRIPTION
Merges workflow optional RELEASE_MANIFEST_MERGE_PAT, runbook troubleshooting (§8–§9), and sync with main.

Made with [Cursor](https://cursor.com)