### PR TITLE
fix(ci): stack-check ripgrep alleen installeren als rg ontbreekt

### DIFF
--- a/.github/workflows/reusable-check-stack.yml
+++ b/.github/workflows/reusable-check-stack.yml
@@ -40,8 +40,16 @@ jobs:
           ref: main
           path: .maintenance
 
+      # Shell-precedence op de oude one-liner deed `apt-get install` ook wanneer `rg`
+      # al bestond ((A || B) && C). Alleen bij ontbrekende `rg`: update + install.
       - name: Install ripgrep (fallback — pre-installed op github-hosted ubuntu-latest)
-        run: command -v rg >/dev/null 2>&1 || sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep
+        run: |
+          if command -v rg >/dev/null 2>&1; then
+            echo "ripgrep (rg) already on PATH — skipping apt"
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep
 
       - name: Run drift guard (single-repo mode)
         env:


### PR DESCRIPTION
Vervangt de one-liner waar door `||`/`&&`-precedence `apt-get install` ook draaide als `rg` al op PATH stond. Nu: expliciet `if command -v rg`; anders pas `apt-get update` + install. Minder ruis en geen onnodige apt op ubuntu-latest.

Made with [Cursor](https://cursor.com)