### PR TITLE
docs: sync-script voor RELEASE_MANIFEST_TOKEN op consumer-repos

### DIFF
--- a/RUNBOOK-release-manifest.md
+++ b/RUNBOOK-release-manifest.md
@@ -67,6 +67,18 @@ Voeg de PAT toe als repository secret `RELEASE_MANIFEST_TOKEN` in elk van:
 
 De default `GITHUB_TOKEN` kan geen workflows in andere repo's dispatchen, vandaar de PAT.
 
+### 3.3 Sync met één commando (na PAT aanmaken)
+
+Als de PAT in de browser staat, zet je hem op alle consumer-repos zonder handmatig vier keer te plakken:
+
+```bash
+cd pagayo-maintenance
+chmod +x scripts/sync-github-release-manifest-token.sh
+RELEASE_MANIFEST_PAT='…plak hier de nieuwe PAT…' ./scripts/sync-github-release-manifest-token.sh
+```
+
+Gebruik bij voorkeur een **nieuwe** fine-grained PAT (§3.1), niet je brede persoonlijke `gh`-token: die token verloopt of wisselt van scope mee met je account.
+
 ## 4. Rollback
 
 Scenario: productie draait een nieuwe release en die is kapot. We willen terug naar een eerdere known-good SHA.

--- a/scripts/sync-github-release-manifest-token.sh
+++ b/scripts/sync-github-release-manifest-token.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Zet GitHub-repo-secret RELEASE_MANIFEST_TOKEN op alle consumer-repos.
+# Vereist een PAT die workflow_dispatch mag doen op Pagayo/pagayo-maintenance.
+# Aanbevolen: fine-grained PAT (zie RUNBOOK-release-manifest.md §3.1).
+# =============================================================================
+set -euo pipefail
+
+CONSUMER_REPOS=(
+  Pagayo/pagayo-storefront
+  Pagayo/pagayo-api-stack
+  Pagayo/pagayo-edge
+  Pagayo/pagayo-workflows
+)
+
+usage() {
+  echo "Gebruik:" >&2
+  echo "  RELEASE_MANIFEST_PAT=<token> $0" >&2
+  echo "" >&2
+  echo "Maak eerst een fine-grained PAT (resource owner Pagayo, alleen repo" >&2
+  echo "pagayo-maintenance, Actions: Read and write). Zie RUNBOOK-release-manifest.md §3.1." >&2
+  exit 1
+}
+
+if [[ -z "${RELEASE_MANIFEST_PAT:-}" ]]; then
+  usage
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh is niet ingelogd (gh auth login)." >&2
+  exit 1
+fi
+
+for repo in "${CONSUMER_REPOS[@]}"; do
+  echo "→ RELEASE_MANIFEST_TOKEN op ${repo} …"
+  printf '%s' "${RELEASE_MANIFEST_PAT}" | gh secret set RELEASE_MANIFEST_TOKEN -R "${repo}" --body -
+done
+
+echo "Klaar: ${#CONSUMER_REPOS[@]} repo's bijgewerkt."


### PR DESCRIPTION
Voegt `scripts/sync-github-release-manifest-token.sh` toe en documenteert gebruik in RUNBOOK §3.3. Fine-grained PAT blijft handmatig in GitHub aanmaken; het script voorkomt vier keer hetzelfde plakken in repo-secrets.

Operationeel zijn alle vier consumer-repos al bijgewerkt met een werkende token; deze PR is voor herhaalbaarheid en documentatie.

Made with [Cursor](https://cursor.com)