### PR TITLE
fix(ci): stack-check ripgrep install without apt-get

### DIFF
--- a/.github/workflows/reusable-check-stack.yml
+++ b/.github/workflows/reusable-check-stack.yml
@@ -40,16 +40,26 @@ jobs:
           ref: main
           path: .maintenance
 
-      # Shell-precedence op de oude one-liner deed `apt-get install` ook wanneer `rg`
-      # al bestond ((A || B) && C). Alleen bij ontbrekende `rg`: update + install.
-      - name: Install ripgrep (fallback — pre-installed op github-hosted ubuntu-latest)
+      # Meestal staat `rg` al op ubuntu-latest. Als die ontbreekt: géén apt-get hier —
+      # `apt-get update`/`install` hangt soms minutenlang (mirrors/locks). Pin upstream
+      # musl-binary (curl + tar) is snel en deterministisch.
+      - name: Install ripgrep (fallback — GitHub release, no apt)
         run: |
+          set -euo pipefail
           if command -v rg >/dev/null 2>&1; then
-            echo "ripgrep (rg) already on PATH — skipping apt"
+            echo "ripgrep (rg) already on PATH — skipping install"
             exit 0
           fi
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq ripgrep
+          RG_VER=14.1.1
+          RG_TGZ="ripgrep-${RG_VER}-x86_64-unknown-linux-musl.tar.gz"
+          RG_DIR="ripgrep-${RG_VER}-x86_64-unknown-linux-musl"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          curl -fsSL --max-time 120 \
+            "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VER}/${RG_TGZ}" \
+            | tar xz -C "$tmp"
+          sudo install -m 0755 "${tmp}/${RG_DIR}/rg" /usr/local/bin/rg
+          rg --version
 
       - name: Run drift guard (single-repo mode)
         env:

--- a/.github/workflows/stack-check.yml
+++ b/.github/workflows/stack-check.yml
@@ -17,7 +17,8 @@ permissions:
   contents: read
 
 jobs:
-  # Self-reference naar dezelfde staging-ref tijdens grounding-batch.
-  # TODO: Switch to @main after grounding batch merge.
+  # Zelfde repo: gebruik een relatieve `uses:` zodat PR’s altijd de reusable op
+  # **dezelfde ref** draaien. Een pin naar een oude feature-branch (bv. 20260416)
+  # laat CI eeuwig de verouderde reusable draaien — inclusief apt-fallback voor rg.
   stack-check:
-    uses: Pagayo/pagayo-maintenance/.github/workflows/reusable-check-stack.yml@feature/batch-staging-20260416
+    uses: ./.github/workflows/reusable-check-stack.yml


### PR DESCRIPTION
## Problem
Reusable `stack-check` fell back to `sudo apt-get update` + `apt-get install ripgrep` when `rg` was missing. On GitHub-hosted runners this step can hang for many minutes (mirror slowness, locks), blocking deploy and other workflows that call this reusable workflow.

## Change
If `rg` is not on PATH, install the pinned BurntSushi **x86_64-unknown-linux-musl** release via curl + tar (120s max), then `install` to `/usr/local/bin/rg`. No apt.

## Notes
- `ubuntu-latest` normally already has `rg`; this path is only the fallback.
- Consumers use `Pagayo/pagayo-maintenance/.github/workflows/reusable-check-stack.yml@main` — merge to `main` is required for the fix to apply.

Made with [Cursor](https://cursor.com)