### PR TITLE
test(maintenance): extend storefront staging smoke coverage

### DIFF
--- a/tests/smoke/storefront.test.ts
+++ b/tests/smoke/storefront.test.ts
@@ -2716,6 +2716,30 @@ describe("Storefront Service - Smoke Tests", () => {
       expect(response.status).toBe(401);
     });
 
+    it("POST /api/admin/subscriptions/:id/purchase-extra-slots returns 401 without auth", async () => {
+      const response = await fetch(
+        `${STOREFRONT_URL}/api/admin/subscriptions/1/purchase-extra-slots`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            count: 1,
+            paymentStatus: "pending",
+            adminPaymentMethod: "admin_invoice",
+          }),
+        },
+      );
+      if (skipIfNoTenant(response, "admin-subscriptions-extra-slots-no-auth")) {
+        return;
+      }
+      log(
+        "admin-subscriptions-extra-slots-no-auth",
+        response.status === 401 ? "PASS" : "FAIL",
+        `Status: ${response.status}`,
+      );
+      expect(response.status).toBe(401);
+    });
+
     it("GET /api/subscription returns 401 without auth", async () => {
       const response = await fetch(`${STOREFRONT_URL}/api/subscription`);
       if (skipIfNoTenant(response, "customer-subscriptions-no-auth")) return;

--- a/tests/smoke/storefront.test.ts
+++ b/tests/smoke/storefront.test.ts
@@ -679,13 +679,36 @@ describe("Storefront Service - Smoke Tests", () => {
       expect(response.headers.get("content-type")).toContain("text/html");
     });
 
-    it("Contact page serves HTML", async () => {
+    it("Contact page serves HTML with aligned markup contract", async () => {
       const response = await fetch(`${STOREFRONT_URL}/contact`);
 
       if (skipIfNoTenant(response, "contact-page")) return;
 
       if (response.status === 200) {
-        log("contact-page", "PASS", "Contact page accessible");
+        const html = await response.text();
+        const hasAlignedMarkup =
+          html.includes('class="page-title"') &&
+          html.includes('class="contact-form"') &&
+          html.includes('class="contact-sidebar"') &&
+          html.includes("/design/dist/") &&
+          html.includes("webshop.css?") &&
+          html.includes("&d=") &&
+          !html.includes("contact-form-shell") &&
+          !html.includes("contact-title");
+
+        if (hasAlignedMarkup) {
+          log("contact-page", "PASS", "Contact markup + design stylesheet contract OK");
+        } else {
+          log(
+            "contact-page",
+            "FAIL",
+            "Contact HTML mist aligned SSR markup of design stylesheet bust",
+            "Check storefront-partials renderContactBody + design-asset-version",
+            "HIGH",
+          );
+        }
+
+        expect(hasAlignedMarkup).toBe(true);
       } else {
         log(
           "contact-page",


### PR DESCRIPTION
## Summary
- assert the contact page markup and design cache-bust contract in the storefront smoke suite
- cover the new admin subscription extra-slot endpoint auth contract so staging regressions fail early in maintenance

## Test plan
- `npm test -- tests/smoke/storefront.test.ts`
- `gh run list --repo Pagayo/pagayo-maintenance --branch feature/batch-staging-20260525 --limit 1`


Made with [Cursor](https://cursor.com)