### PR TITLE
fix(quality): make cloudflare token-expiry test cwd CI-safe

### DIFF
--- a/.github/scripts/local-dev-daemon.py
+++ b/.github/scripts/local-dev-daemon.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Detach a long-running local dev process (survives Cursor/shell exit)."""
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) < 5:
+        print("usage: local-dev-daemon.py WORKDIR LOG PIDFILE CMD...", file=sys.stderr)
+        sys.exit(2)
+
+    workdir = sys.argv[1]
+    log_path = sys.argv[2]
+    pidfile = sys.argv[3]
+    cmd = sys.argv[4:]
+
+    if os.fork() > 0:
+        sys.exit(0)
+
+    os.setsid()
+
+    if os.fork() > 0:
+        sys.exit(0)
+
+    with open(pidfile, "w", encoding="utf-8") as handle:
+        handle.write(str(os.getpid()))
+
+    os.chdir(workdir)
+    os.environ["CI"] = "true"
+    os.environ["WRANGLER_SEND_METRICS"] = "false"
+
+    with open(log_path, "a", encoding="utf-8", buffering=1) as log:
+        os.dup2(log.fileno(), 1)
+        os.dup2(log.fileno(), 2)
+
+    os.execvp(cmd[0], cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/local-dev-lib.sh
+++ b/.github/scripts/local-dev-lib.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# Gedeelde functies voor persistente lokale Pagayo dev (macOS Terminal + migraties).
+# Afgeleid van pagayo-vault/Start Wrangler Lokaal.command en Wrangler refresh.command
+
+# shellcheck disable=SC2034
+local_dev_lib_loaded=true
+
+local_dev_resolve_workspace() {
+  local script_dir="$1"
+  if [[ -n "${PAGAYO_WORKSPACE:-}" && -d "$PAGAYO_WORKSPACE/pagayo-storefront" ]]; then
+    echo "$PAGAYO_WORKSPACE"
+    return 0
+  fi
+  # pagayo-maintenance/.github/scripts -> workspace root
+  cd "$script_dir/../../.." && pwd
+}
+
+local_dev_export_wrangler_env() {
+  export CI=true
+  export WRANGLER_SEND_METRICS=false
+}
+
+local_dev_stop_wrangler_and_ports() {
+  local existing
+  existing="$(pgrep -f "wrangler" 2>/dev/null | wc -l | tr -d ' ')" || existing=0
+  if [[ "${existing:-0}" -gt 0 ]]; then
+    echo "⚠️  $existing wrangler-process(en) — stoppen (SQLite lock voorkomen)..."
+    pkill -f "wrangler" 2>/dev/null || true
+    sleep 2
+    local remaining
+    remaining="$(pgrep -f "wrangler" 2>/dev/null | wc -l | tr -d ' ')" || remaining=0
+    if [[ "${remaining:-0}" -gt 0 ]]; then
+      pkill -9 -f "wrangler" 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+
+  for PORT in 3000 5173 5500 8787 4321 9229 9230; do
+    local pid=""
+    pid="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1)" || true
+    if [[ -n "$pid" ]]; then
+      echo "⚠️  Poort $PORT bezet (PID $pid) — vrijmaken..."
+      kill "$pid" 2>/dev/null || true
+      sleep 1
+    fi
+  done
+}
+
+local_dev_apply_tenant_migrations() {
+  local ws="$1"
+  echo "🧩 Storefront lokale tenant migraties..."
+  (
+    cd "$ws/pagayo-storefront" || exit 1
+    local_dev_export_wrangler_env
+    npx tsx ./scripts/apply-local-tenant-migrations.ts
+  )
+  echo ""
+}
+
+local_dev_apply_api_migrations() {
+  local ws="$1"
+  echo "🧱 API Stack lokale D1 migraties..."
+  (
+    cd "$ws/pagayo-api-stack" || exit 1
+    local_dev_export_wrangler_env
+
+    local api_migration_dir="node_modules/@pagayo/schema/migrations/api-v2"
+    local api_db_name="pagayo-api"
+
+    if [[ ! -d "$api_migration_dir" ]]; then
+      echo "⚠️  Geen API migratie directory: $api_migration_dir"
+      return 0
+    fi
+
+    npx wrangler d1 execute "$api_db_name" \
+      --local \
+      --yes \
+      --command="CREATE TABLE IF NOT EXISTS _migration_log (filename TEXT PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')), checksum TEXT NOT NULL);" >/dev/null
+
+    local applied=0 skipped=0
+    local sql_file filename checksum result output apply_ok
+
+    while IFS= read -r sql_file; do
+      filename="$(basename "$sql_file")"
+      checksum="$(shasum -a 256 "$sql_file" | awk '{print $1}')"
+
+      result="$(npx wrangler d1 execute "$api_db_name" \
+        --local \
+        --yes \
+        --command="SELECT filename FROM _migration_log WHERE filename='$filename';" 2>&1)" || true
+
+      if echo "$result" | grep -q "$filename"; then
+        skipped=$((skipped + 1))
+        continue
+      fi
+
+      apply_ok=false
+      if output="$(npx wrangler d1 execute "$api_db_name" \
+        --local \
+        --yes \
+        --file="$sql_file" 2>&1)"; then
+        apply_ok=true
+      fi
+
+      if [[ "$apply_ok" == true ]]; then
+        npx wrangler d1 execute "$api_db_name" \
+          --local \
+          --yes \
+          --command="INSERT OR REPLACE INTO _migration_log (filename, checksum) VALUES ('$filename', '$checksum');" >/dev/null || true
+        applied=$((applied + 1))
+      elif echo "$output" | grep -qiE "already exists|duplicate column|UNIQUE constraint.*_migration_log|SQLITE_CONSTRAINT.*_migration_log"; then
+        npx wrangler d1 execute "$api_db_name" \
+          --local \
+          --yes \
+          --command="INSERT OR REPLACE INTO _migration_log (filename, checksum) VALUES ('$filename', '$checksum');" >/dev/null || true
+        applied=$((applied + 1))
+      else
+        echo "❌ API migratie geblokkeerd: $filename"
+        echo "$output"
+        return 1
+      fi
+    done < <(find "$api_migration_dir" -maxdepth 1 -name "*.sql" -type f | sort)
+
+    echo "   ✅ API D1: $applied toegepast, $skipped overgeslagen"
+  )
+  echo ""
+}
+
+local_dev_bootstrap_preserve() {
+  local ws="$1"
+  local wrangler_state_dir="$ws/.wrangler-shared/v3/d1"
+
+  if [[ -d "$wrangler_state_dir" ]]; then
+    echo "💾 Bestaande lokale D1 state — tenantdata blijft behouden."
+    echo "   Geen fresh reset."
+  else
+    echo "🗑️  Geen lokale D1 state — fresh bootstrap..."
+    (
+      cd "$ws/pagayo-storefront" || exit 1
+      local_dev_export_wrangler_env
+      ./scripts/setup-local-d1.sh --fresh
+    )
+  fi
+  echo ""
+}
+
+local_dev_bootstrap_fresh() {
+  local ws="$1"
+  echo "🗑️  Fresh D1 databases..."
+  (
+    cd "$ws/pagayo-storefront" || exit 1
+    local_dev_export_wrangler_env
+    ./scripts/setup-local-d1.sh --fresh
+  )
+  echo ""
+}
+
+# Start services in macOS Terminal.app — blijft draaien na sluiten Cursor/agent.
+local_dev_runtime_dir() {
+  echo "/tmp/pagayo-local-dev"
+}
+
+local_dev_spawn_background() {
+  local name="$1"
+  local workdir="$2"
+  shift 2
+  local dir log pidfile daemon pid prev_dir
+
+  dir="$(local_dev_runtime_dir)"
+  log="$dir/$name.log"
+  pidfile="$dir/$name.pid"
+  daemon="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/local-dev-daemon.py"
+  mkdir -p "$dir"
+
+  if [[ ! -f "$daemon" ]]; then
+    echo "❌ Daemon helper ontbreekt: $daemon"
+    return 1
+  fi
+
+  prev_dir="$(pwd)"
+  python3 "$daemon" "$workdir" "$log" "$pidfile" "$@"
+  cd "$prev_dir" || true
+
+  if [[ -f "$pidfile" ]]; then
+    pid="$(cat "$pidfile")"
+    echo "   ▶ $name (PID $pid)"
+  else
+    echo "   ▶ $name (gestart)"
+  fi
+}
+
+local_dev_start_background_services() {
+  local ws="$1"
+
+  echo "🚀 Services starten op achtergrond (geen Terminal-vensters)..."
+  echo "   Logs: $(local_dev_runtime_dir)/"
+
+  local_dev_spawn_background "storefront" "$ws/pagayo-storefront" \
+    bash -lc "npm run copy-design && exec npx concurrently --names wrangler,static -c cyan,magenta 'wrangler dev --persist-to ../.wrangler-shared' 'npm run serve:public'"
+
+  sleep 2
+
+  local_dev_spawn_background "vite" "$ws/pagayo-storefront" npm run dev:client
+  sleep 1
+  local_dev_spawn_background "api-stack" "$ws/pagayo-api-stack" npm run dev
+  local_dev_spawn_background "marketing" "$ws/pagayo-marketing" npm run dev
+}
+
+local_dev_stop_background_pids() {
+  local dir pidfile pid
+
+  dir="$(local_dev_runtime_dir)"
+  [[ -d "$dir" ]] || return 0
+
+  for pidfile in "$dir"/*.pid; do
+    [[ -f "$pidfile" ]] || continue
+    pid="$(cat "$pidfile" 2>/dev/null)" || continue
+    [[ -n "$pid" ]] || continue
+    kill "$pid" 2>/dev/null || true
+  done
+}
+
+local_dev_start_terminal_services() {
+  local ws="$1"
+
+  if ! command -v osascript >/dev/null 2>&1; then
+    echo "❌ osascript niet beschikbaar — Terminal-start vereist macOS."
+    return 1
+  fi
+
+  echo "🚀 Services openen in Terminal.app (blijven draaien)..."
+
+  osascript -e "tell application \"Terminal\"
+    do script \"cd '$ws/pagayo-storefront' && npm run copy-design && npx concurrently --names 'wrangler,static' -c 'cyan,magenta' 'wrangler dev --persist-to ../.wrangler-shared' 'npm run serve:public'\"
+end tell"
+
+  sleep 2
+
+  osascript -e "tell application \"Terminal\"
+    do script \"cd '$ws/pagayo-storefront' && npm run dev:client\"
+end tell"
+
+  sleep 2
+
+  osascript -e "tell application \"Terminal\"
+    do script \"cd '$ws/pagayo-api-stack' && npm run dev\"
+end tell"
+
+  osascript -e "tell application \"Terminal\"
+    do script \"cd '$ws/pagayo-marketing' && npm run dev\"
+end tell"
+}
+
+local_dev_print_urls() {
+  local fresh_note="${1:-}"
+  local mode="${2:-background}"
+  echo ""
+  if [[ "$mode" == "terminal" ]]; then
+    echo "✅ Alle services worden gestart in Terminal.app!"
+  else
+    echo "✅ Alle services draaien op de achtergrond."
+  fi
+  echo ""
+  echo "📍 URLs:"
+  echo "   Platform Admin:   http://admin.localhost:3000/platform"
+  echo "   Tenant Admin:     http://demo.localhost:3000/admin"
+  echo "   Webshop:          http://demo.localhost:3000"
+  echo "   Vite:             http://localhost:5173/assets/"
+  echo "   Design CSS:       http://localhost:5500/design/dist/fresh/webshop.css"
+  echo "   API Stack:        http://localhost:8787"
+  echo "   Marketing:        http://localhost:4321"
+  echo ""
+  echo "👤 Admin: dev@pagayo.com / admin123"
+  echo "🌱 Tenants: demo, test"
+  if [[ -n "$fresh_note" ]]; then
+    echo ""
+    echo "$fresh_note"
+  fi
+  echo ""
+  if [[ "$mode" == "terminal" ]]; then
+    echo "Terminal-vensters open laten. Stop: pagayo-maintenance/.github/scripts/local-dev-stop.sh"
+  else
+    echo "Logs: $(local_dev_runtime_dir)/   Stop: pagayo-maintenance/.github/scripts/local-dev-stop.sh"
+  fi
+}
+
+local_dev_wait_for_health() {
+  local max_seconds="${1:-45}"
+  local deadline=$((SECONDS + max_seconds))
+  echo "⏳ Wachten op poorten (max ${max_seconds}s)..."
+  while (( SECONDS < deadline )); do
+    if curl -sf --max-time 2 http://demo.localhost:3000/ >/dev/null 2>&1 \
+      && curl -sf --max-time 2 http://localhost:5173/assets/ >/dev/null 2>&1 \
+      && curl -sf --max-time 2 http://localhost:5500/design/dist/fresh/webshop.css >/dev/null 2>&1 \
+      && curl -sf --max-time 2 http://localhost:8787/ >/dev/null 2>&1; then
+      echo "✅ Health check OK"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "⚠️  Nog niet alle poorten reageerden — services hebben mogelijk meer tijd nodig."
+  return 1
+}

--- a/.github/scripts/local-dev-refresh.sh
+++ b/.github/scripts/local-dev-refresh.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Pagayo — lokale dev starten met fresh D1 reset
+# Standaard: achtergrond. Optioneel: --terminal
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=local-dev-lib.sh
+source "$SCRIPT_DIR/local-dev-lib.sh"
+
+MODE="${PAGAYO_LOCAL_DEV_MODE:-background}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --terminal) MODE=terminal ;;
+    --background) MODE=background ;;
+    *)
+      echo "Onbekende optie: $1 (gebruik --background of --terminal)"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+WS="$(local_dev_resolve_workspace "$SCRIPT_DIR")"
+
+echo "🚀 Pagayo Local Dev — fresh reset ($MODE)"
+echo "   Workspace: $WS"
+echo ""
+
+local_dev_stop_wrangler_and_ports
+local_dev_stop_background_pids
+echo ""
+
+local_dev_bootstrap_fresh "$WS"
+local_dev_apply_tenant_migrations "$WS"
+local_dev_apply_api_migrations "$WS"
+
+if [[ "$MODE" == "terminal" ]]; then
+  local_dev_start_terminal_services "$WS"
+else
+  local_dev_start_background_services "$WS"
+fi
+
+local_dev_print_urls "⚠️  Lokale tenantdata is opnieuw gebootstrap — demo/test tenants via platform seed." "$MODE"
+
+local_dev_wait_for_health 60 || true

--- a/.github/scripts/local-dev-start.sh
+++ b/.github/scripts/local-dev-start.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Pagayo — lokale dev starten (data behouden)
+# Standaard: achtergrond (geen Terminal-vensters). Optioneel: --terminal
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=local-dev-lib.sh
+source "$SCRIPT_DIR/local-dev-lib.sh"
+
+MODE="${PAGAYO_LOCAL_DEV_MODE:-background}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --terminal) MODE=terminal ;;
+    --background) MODE=background ;;
+    *)
+      echo "Onbekende optie: $1 (gebruik --background of --terminal)"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+WS="$(local_dev_resolve_workspace "$SCRIPT_DIR")"
+
+echo "🚀 Pagayo Local Dev — start (data behouden, $MODE)"
+echo "   Workspace: $WS"
+echo ""
+
+local_dev_stop_wrangler_and_ports
+local_dev_stop_background_pids
+echo ""
+
+local_dev_bootstrap_preserve "$WS"
+local_dev_apply_tenant_migrations "$WS"
+local_dev_apply_api_migrations "$WS"
+
+if [[ "$MODE" == "terminal" ]]; then
+  local_dev_start_terminal_services "$WS"
+else
+  local_dev_start_background_services "$WS"
+fi
+
+local_dev_print_urls "" "$MODE"
+
+local_dev_wait_for_health 45 || true

--- a/.github/scripts/local-dev-status.sh
+++ b/.github/scripts/local-dev-status.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Pagayo — status lokale dev-stack (poorten + health + achtergrond-PIDs)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=local-dev-lib.sh
+source "$SCRIPT_DIR/local-dev-lib.sh"
+
+WS="$(local_dev_resolve_workspace "$SCRIPT_DIR")"
+RUNTIME="$(local_dev_runtime_dir)"
+
+echo "Pagayo local dev — status"
+echo "Workspace: $WS"
+echo ""
+
+if [[ -d "$RUNTIME" ]] && compgen -G "$RUNTIME/*.pid" >/dev/null; then
+  echo "Achtergrond-processen ($RUNTIME):"
+  for pidfile in "$RUNTIME"/*.pid; do
+    [[ -f "$pidfile" ]] || continue
+    name="$(basename "$pidfile" .pid)"
+    pid="$(cat "$pidfile" 2>/dev/null)" || pid="?"
+    if [[ -n "$pid" && "$pid" != "?" ]] && kill -0 "$pid" 2>/dev/null; then
+      echo "  $name: PID $pid (actief)"
+    else
+      echo "  $name: PID $pid (niet actief)"
+    fi
+  done
+  echo ""
+fi
+
+echo "Processen (wrangler/vite/serve/astro):"
+pgrep -fl "wrangler dev|serve public|/vite|astro dev" 2>/dev/null | head -10 || echo "  (geen matches)"
+echo ""
+
+echo "Poorten:"
+for PORT in 3000 5173 5500 8787 4321; do
+  pid="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1)" || true
+  echo "  $PORT: ${pid:-vrij}"
+done
+echo ""
+
+local_dev_wait_for_health 5 || true

--- a/.github/scripts/local-dev-stop.sh
+++ b/.github/scripts/local-dev-stop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Pagayo — lokale dev-stack stoppen (wrangler, vite, serve, astro, poorten)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=local-dev-lib.sh
+source "$SCRIPT_DIR/local-dev-lib.sh"
+
+echo "🛑 Pagayo Local Dev — stoppen"
+local_dev_stop_background_pids
+local_dev_stop_wrangler_and_ports
+
+pkill -f "serve public" 2>/dev/null || true
+pkill -f "pagayo-storefront/node_modules/.bin/vite" 2>/dev/null || true
+pkill -f "astro dev" 2>/dev/null || true
+pkill -f "concurrently" 2>/dev/null || true
+
+echo "✅ Local dev stack gestopt"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -50,11 +50,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Private cross-repo checkout: gebruik de dedicated read token wanneer die bestaat,
-      # anders valt dit terug op de bestaande merge-PAT die al in maintenance aanwezig is.
+      # Private cross-repo checkout: vereist een repo-read PAT voor Pagayo/pagayo-schema.
       - name: Require pagayo-schema checkout token
         env:
-          PAGAYO_SCHEMA_CHECKOUT_TOKEN: ${{ secrets.PAGAYO_SCHEMA_CHECKOUT_TOKEN || secrets.RELEASE_MANIFEST_MERGE_PAT }}
+          PAGAYO_SCHEMA_CHECKOUT_TOKEN: ${{ secrets.PAGAYO_SCHEMA_CHECKOUT_TOKEN }}
         run: |
           if [ -z "${PAGAYO_SCHEMA_CHECKOUT_TOKEN:-}" ]; then
             echo "::error::Missing PAGAYO_SCHEMA_CHECKOUT_TOKEN secret; checkout of Pagayo/pagayo-schema requires a repo-read PAT."
@@ -66,7 +65,7 @@ jobs:
         with:
           repository: Pagayo/pagayo-schema
           path: pagayo-schema
-          token: ${{ secrets.PAGAYO_SCHEMA_CHECKOUT_TOKEN || secrets.RELEASE_MANIFEST_MERGE_PAT }}
+          token: ${{ secrets.PAGAYO_SCHEMA_CHECKOUT_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -50,11 +50,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Private cross-repo checkout: gebruik de dedicated read token wanneer die bestaat,
+      # anders valt dit terug op de bestaande merge-PAT die al in maintenance aanwezig is.
+      - name: Require pagayo-schema checkout token
+        env:
+          PAGAYO_SCHEMA_CHECKOUT_TOKEN: ${{ secrets.PAGAYO_SCHEMA_CHECKOUT_TOKEN || secrets.RELEASE_MANIFEST_MERGE_PAT }}
+        run: |
+          if [ -z "${PAGAYO_SCHEMA_CHECKOUT_TOKEN:-}" ]; then
+            echo "::error::Missing PAGAYO_SCHEMA_CHECKOUT_TOKEN secret; checkout of Pagayo/pagayo-schema requires a repo-read PAT."
+            exit 1
+          fi
+
       - name: Checkout pagayo-schema
         uses: actions/checkout@v4
         with:
           repository: Pagayo/pagayo-schema
           path: pagayo-schema
+          token: ${{ secrets.PAGAYO_SCHEMA_CHECKOUT_TOKEN || secrets.RELEASE_MANIFEST_MERGE_PAT }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "health": "./scripts/health-check.sh",
     "health:quick": "./scripts/health-check.sh --quick",
     "health:access": "./scripts/health-check.sh --access",
+    "local:dev:start": "./.github/scripts/local-dev-start.sh",
+    "local:dev:refresh": "./.github/scripts/local-dev-refresh.sh",
+    "local:dev:stop": "./.github/scripts/local-dev-stop.sh",
+    "local:dev:status": "./.github/scripts/local-dev-status.sh",
     "cloudflare:token:check": "node scripts/cloudflare/token-expiry-check.mjs",
     "cloudflare:token:check:json": "node scripts/cloudflare/token-expiry-check.mjs --json",
     "cloudflare:token:check:dry": "node scripts/cloudflare/token-expiry-check.mjs --dry-run --json"

--- a/tests/quality/cloudflare-token-expiry.test.ts
+++ b/tests/quality/cloudflare-token-expiry.test.ts
@@ -64,6 +64,7 @@ describe("Cloudflare token expiry helpers", () => {
 describe("Cloudflare token expiry CLI", () => {
   const scriptPath = "scripts/cloudflare/token-expiry-check.mjs";
   const nodeExecutable = process.execPath;
+  const repoRoot = process.cwd();
 
   const parseJsonOutput = <T>(rawOutput: string, context: string): T => {
     const trimmedOutput = rawOutput.trim();
@@ -84,7 +85,7 @@ describe("Cloudflare token expiry CLI", () => {
 
   it("dry-run json mode retourneert success payload", () => {
     const output = execFileSync(nodeExecutable, [scriptPath, "--dry-run", "--json"], {
-      cwd: "/Users/sjoerdoverdiep/my-vscode-workspace/pagayo-maintenance",
+      cwd: repoRoot,
       encoding: "utf-8",
     });
 
@@ -107,7 +108,7 @@ describe("Cloudflare token expiry CLI", () => {
 
     try {
       execFileSync(nodeExecutable, [scriptPath, "--json"], {
-        cwd: "/Users/sjoerdoverdiep/my-vscode-workspace/pagayo-maintenance",
+        cwd: repoRoot,
         encoding: "utf-8",
         env: {
           PATH: process.env.PATH ?? "",

--- a/tests/smoke/api-stack.test.ts
+++ b/tests/smoke/api-stack.test.ts
@@ -15,6 +15,7 @@
 import { logTestResult, type TestResult } from "../utils/test-reporter";
 
 const API_URL = "https://api.pagayo.com";
+const API_INTERNAL_SERVICE_KEY = process.env.API_INTERNAL_SERVICE_KEY;
 const INVALID_SHOP_HEADERS = {
   "X-Shop-ID": "shop_invalid_999",
   "X-API-Key": "pk_live_shop_invalid_999_deadbeef",
@@ -101,6 +102,59 @@ describe("API Stack Service - Smoke Tests", () => {
 
       expect(response.status).toBe(200);
       expect(["ready", "degraded"]).toContain(data?.status);
+    });
+
+    it("API detailed health toont webhook rate limiter status (optional)", async () => {
+      if (!API_INTERNAL_SERVICE_KEY) {
+        log(
+          "api-detailed-rate-limiter",
+          "SKIP",
+          "API_INTERNAL_SERVICE_KEY niet gezet; internal health positive-path overgeslagen",
+        );
+        return;
+      }
+
+      const response = await fetch(`${API_URL}/api/health/detailed`, {
+        headers: {
+          "X-Edge-Secret": API_INTERNAL_SERVICE_KEY,
+        },
+      });
+
+      const data =
+        response.status === 200
+          ? ((await response.json()) as {
+              checks?: {
+                rateLimiter?: {
+                  status?: string;
+                  type?: string;
+                };
+              };
+            })
+          : null;
+
+      const rateLimiter = data?.checks?.rateLimiter;
+      const isConfigured =
+        rateLimiter?.status === "ok" &&
+        rateLimiter?.type === "kv-webhook-window";
+
+      if (response.status === 200 && isConfigured) {
+        log(
+          "api-detailed-rate-limiter",
+          "PASS",
+          "Webhook rate limiter configured via kv-webhook-window",
+        );
+      } else {
+        log(
+          "api-detailed-rate-limiter",
+          "FAIL",
+          `Onverwachte detailed health rateLimiter status: HTTP ${response.status}, status=${rateLimiter?.status ?? "unknown"}, type=${rateLimiter?.type ?? "unknown"}`,
+          "Check API Stack webhook rate-limit backend/config",
+          "CRITICAL",
+        );
+      }
+
+      expect(response.status).toBe(200);
+      expect(isConfigured).toBe(true);
     });
 
     it("Root endpoint returns 200", async () => {

--- a/tests/smoke/storefront.test.ts
+++ b/tests/smoke/storefront.test.ts
@@ -684,6 +684,671 @@ describe("Storefront Service - Smoke Tests", () => {
       expect(["no-store", "no-cache"]).toContain(cacheControl);
     });
 
+    it("Public settings endpoint exposes storefrontContentBlocks contract", async () => {
+      const response = await fetch(`${STOREFRONT_URL}/api/settings/public`);
+
+      if (skipIfNoTenant(response, "public-settings-storefront-content-blocks"))
+        return;
+
+      const body = response.status === 200 ? await response.json() : null;
+      const data =
+        body &&
+        typeof body === "object" &&
+        typeof body.data === "object" &&
+        body.data
+          ? (body.data as Record<string, unknown>)
+          : null;
+      const blocks =
+        data &&
+        typeof data.storefrontContentBlocks === "object" &&
+        data.storefrontContentBlocks
+          ? (data.storefrontContentBlocks as Record<string, unknown>)
+          : null;
+      const version = blocks?.version;
+      const library = blocks?.library;
+      const placements = blocks?.placements;
+
+      expect(response.status).toBe(200);
+
+      if (!blocks) {
+        log(
+          "public-settings-storefront-content-blocks",
+          "WARN",
+          "storefrontContentBlocks ontbreekt nog in deze omgeving; contract-check wordt overgeslagen",
+          "Deploy storefront met blocks public-settings payload en draai smoke opnieuw",
+          "HIGH",
+        );
+        return;
+      }
+
+      if (
+        response.status === 200 &&
+        typeof version === "number" &&
+        Array.isArray(library) &&
+        Array.isArray(placements)
+      ) {
+        log(
+          "public-settings-storefront-content-blocks",
+          "PASS",
+          `contract ok: version=${version}, library=${library.length}, placements=${placements.length}`,
+        );
+      } else {
+        log(
+          "public-settings-storefront-content-blocks",
+          "FAIL",
+          `Onverwachte response: status=${response.status}, version=${String(version)}, libraryIsArray=${Array.isArray(library)}, placementsIsArray=${Array.isArray(placements)}`,
+          "Check /api/settings/public payload contract voor storefrontContentBlocks",
+          "HIGH",
+        );
+      }
+      expect(typeof version).toBe("number");
+      expect(Array.isArray(library)).toBe(true);
+      expect(Array.isArray(placements)).toBe(true);
+    });
+
+    it("SSR storefront block zones render for configured surfaces", async () => {
+      const publicSettingsResponse = await fetch(
+        `${STOREFRONT_URL}/api/settings/public`,
+      );
+
+      if (
+        skipIfNoTenant(
+          publicSettingsResponse,
+          "ssr-storefront-content-zones-configured-surfaces",
+        )
+      ) {
+        return;
+      }
+
+      expect(publicSettingsResponse.status).toBe(200);
+
+      const publicSettingsBody = await readJsonBody(publicSettingsResponse);
+      const publicData =
+        typeof publicSettingsBody?.data === "object" &&
+        publicSettingsBody.data !== null
+          ? (publicSettingsBody.data as Record<string, unknown>)
+          : null;
+      const storefrontContentBlocksRaw = publicData?.storefrontContentBlocks;
+      const storefrontContentBlocks =
+        typeof storefrontContentBlocksRaw === "object" &&
+        storefrontContentBlocksRaw !== null
+          ? (storefrontContentBlocksRaw as Record<string, unknown>)
+          : null;
+
+      if (!storefrontContentBlocks) {
+        log(
+          "ssr-storefront-content-zones-configured-surfaces",
+          "WARN",
+          "storefrontContentBlocks ontbreekt in public settings; SSR zone-check overgeslagen",
+          "Deploy storefront blocks public settings contract op deze omgeving",
+          "HIGH",
+        );
+        return;
+      }
+
+      const rawPlacements = storefrontContentBlocks.placements;
+      const placements = Array.isArray(rawPlacements)
+        ? (rawPlacements as Array<Record<string, unknown>>)
+        : [];
+      const configuredSurfaces = new Set<string>();
+      const configuredZonesBySurface = new Map<
+        "home" | "product" | "category",
+        Set<string>
+      >();
+
+      for (const placement of placements) {
+        const surface = placement.surface;
+        const enabled = placement.enabled;
+        if (
+          (surface === "home" ||
+            surface === "product" ||
+            surface === "category") &&
+          (enabled === undefined || enabled === true)
+        ) {
+          configuredSurfaces.add(surface);
+          const zone = placement.zone;
+          if (typeof zone === "string" && zone.trim().length > 0) {
+            const typedSurface = surface as "home" | "product" | "category";
+            const zones =
+              configuredZonesBySurface.get(typedSurface) ?? new Set<string>();
+            zones.add(zone.trim());
+            configuredZonesBySurface.set(typedSurface, zones);
+          }
+        }
+      }
+
+      if (configuredSurfaces.size === 0) {
+        log(
+          "ssr-storefront-content-zones-configured-surfaces",
+          "WARN",
+          "Geen actieve home/product/category placements gevonden; SSR zone-check overgeslagen",
+          "Configureer minstens één actieve placement voor home, product of category",
+          "HIGH",
+        );
+        return;
+      }
+
+      const assertSsrSurfaceMarker = (
+        html: string,
+        surface: "home" | "product" | "category",
+      ): boolean => {
+        return (
+          html.includes('data-ssr-storefront-content-blocks="true"') &&
+          html.includes(`data-surface="${surface}"`)
+        );
+      };
+
+      const assertSsrZoneMarker = (
+        html: string,
+        surface: "home" | "product" | "category",
+        zone: string,
+      ): boolean => {
+        return (
+          html.includes('data-ssr-storefront-content-blocks="true"') &&
+          html.includes(`data-surface="${surface}"`) &&
+          html.includes(`data-zone="${zone}"`)
+        );
+      };
+
+      if (configuredSurfaces.has("home")) {
+        const homeResponse = await fetch(STOREFRONT_URL);
+        expect(homeResponse.status).toBe(200);
+        const homeHtml = await homeResponse.text();
+        const hasHomeMarker = assertSsrSurfaceMarker(homeHtml, "home");
+        const expectedHomeZones = [
+          ...(configuredZonesBySurface.get("home") ?? new Set<string>()),
+        ];
+        const missingHomeZones = expectedHomeZones.filter(
+          (zone) => !assertSsrZoneMarker(homeHtml, "home", zone),
+        );
+
+        if (hasHomeMarker && missingHomeZones.length === 0) {
+          log(
+            "ssr-storefront-content-zones-home",
+            "PASS",
+            expectedHomeZones.length > 0
+              ? `Home SSR bevat surface+zones (${expectedHomeZones.join(", ")})`
+              : "Home SSR bevat storefront content zone marker",
+          );
+        } else {
+          log(
+            "ssr-storefront-content-zones-home",
+            "FAIL",
+            `Home SSR mist marker of zones (missing: ${missingHomeZones.join(", ") || "geen"})`,
+            "Check home render + storefront blocks injectie",
+            "HIGH",
+          );
+        }
+
+        expect(hasHomeMarker).toBe(true);
+        expect(missingHomeZones).toHaveLength(0);
+      }
+
+      if (configuredSurfaces.has("category")) {
+        const categoriesResponse = await fetch(
+          `${STOREFRONT_URL}/api/categories`,
+        );
+        expect(categoriesResponse.status).toBe(200);
+        const categoriesBody = await readJsonBody(categoriesResponse);
+        const categoriesRaw = categoriesBody?.data;
+        const categories = Array.isArray(categoriesRaw)
+          ? (categoriesRaw as Array<Record<string, unknown>>)
+          : [];
+
+        const sampleCategory = categories.find((entry) => {
+          if (typeof entry.publicPath === "string" && entry.publicPath.trim()) {
+            return true;
+          }
+          if (typeof entry.slug === "string" && entry.slug.trim()) {
+            return true;
+          }
+          return false;
+        });
+
+        const categoryPath =
+          typeof sampleCategory?.publicPath === "string" &&
+          sampleCategory.publicPath.trim()
+            ? sampleCategory.publicPath
+            : typeof sampleCategory?.slug === "string" &&
+                sampleCategory.slug.trim()
+              ? `/${sampleCategory.slug.trim()}`
+              : null;
+
+        if (!categoryPath) {
+          log(
+            "ssr-storefront-content-zones-category",
+            "WARN",
+            "Geen category pad beschikbaar voor SSR zone-check",
+            "Seed een actieve categorie met publicPath/slug",
+            "HIGH",
+          );
+        } else {
+          const categoryResponse = await fetch(
+            `${STOREFRONT_URL}${categoryPath}`,
+          );
+          expect(categoryResponse.status).toBe(200);
+          const categoryHtml = await categoryResponse.text();
+          const hasCategoryMarker = assertSsrSurfaceMarker(
+            categoryHtml,
+            "category",
+          );
+          const expectedCategoryZones = [
+            ...(configuredZonesBySurface.get("category") ?? new Set<string>()),
+          ];
+          const missingCategoryZones = expectedCategoryZones.filter(
+            (zone) => !assertSsrZoneMarker(categoryHtml, "category", zone),
+          );
+
+          if (hasCategoryMarker && missingCategoryZones.length === 0) {
+            log(
+              "ssr-storefront-content-zones-category",
+              "PASS",
+              expectedCategoryZones.length > 0
+                ? `Category SSR bevat surface+zones (${categoryPath}; ${expectedCategoryZones.join(", ")})`
+                : `Category SSR bevat storefront content zone marker (${categoryPath})`,
+            );
+          } else {
+            log(
+              "ssr-storefront-content-zones-category",
+              "FAIL",
+              `Category SSR mist marker of zones (${categoryPath}; missing: ${missingCategoryZones.join(", ") || "geen"})`,
+              "Check category render + storefront blocks injectie",
+              "HIGH",
+            );
+          }
+
+          expect(hasCategoryMarker).toBe(true);
+          expect(missingCategoryZones).toHaveLength(0);
+        }
+      }
+
+      if (configuredSurfaces.has("product")) {
+        const productsResponse = await fetch(
+          `${STOREFRONT_URL}/api/products?limit=1`,
+        );
+        expect(productsResponse.status).toBe(200);
+        const productsBody = await readJsonBody(productsResponse);
+        const productsRaw = productsBody?.data;
+        const products = Array.isArray(productsRaw)
+          ? (productsRaw as Array<Record<string, unknown>>)
+          : [];
+
+        const sampleProduct = products.find((entry) => {
+          return typeof entry.slug === "string" && entry.slug.trim().length > 0;
+        });
+
+        const productSlug =
+          typeof sampleProduct?.slug === "string"
+            ? sampleProduct.slug.trim().replace(/^\/+/, "")
+            : "";
+        const primaryCategoryPublicPath =
+          typeof sampleProduct?.primaryCategoryPublicPath === "string" &&
+          sampleProduct.primaryCategoryPublicPath.trim()
+            ? sampleProduct.primaryCategoryPublicPath.replace(/\/+$/, "")
+            : "";
+        const productPath = productSlug
+          ? primaryCategoryPublicPath
+            ? `${primaryCategoryPublicPath}/${productSlug}`
+            : `/${productSlug}`
+          : null;
+
+        if (!productPath) {
+          log(
+            "ssr-storefront-content-zones-product",
+            "WARN",
+            "Geen product slug beschikbaar voor SSR zone-check",
+            "Seed een actief product met slug",
+            "HIGH",
+          );
+        } else {
+          const productResponse = await fetch(
+            `${STOREFRONT_URL}${productPath}`,
+          );
+          expect(productResponse.status).toBe(200);
+          const productHtml = await productResponse.text();
+          const hasProductMarker = assertSsrSurfaceMarker(
+            productHtml,
+            "product",
+          );
+          const expectedProductZones = [
+            ...(configuredZonesBySurface.get("product") ?? new Set<string>()),
+          ];
+          const missingProductZones = expectedProductZones.filter(
+            (zone) => !assertSsrZoneMarker(productHtml, "product", zone),
+          );
+
+          if (hasProductMarker && missingProductZones.length === 0) {
+            log(
+              "ssr-storefront-content-zones-product",
+              "PASS",
+              expectedProductZones.length > 0
+                ? `Product SSR bevat surface+zones (${productPath}; ${expectedProductZones.join(", ")})`
+                : `Product SSR bevat storefront content zone marker (${productPath})`,
+            );
+          } else {
+            log(
+              "ssr-storefront-content-zones-product",
+              "FAIL",
+              `Product SSR mist marker of zones (${productPath}; missing: ${missingProductZones.join(", ") || "geen"})`,
+              "Check product render + storefront blocks injectie",
+              "HIGH",
+            );
+          }
+
+          expect(hasProductMarker).toBe(true);
+          expect(missingProductZones).toHaveLength(0);
+        }
+      }
+    });
+
+    it("SSR storefront block zones exclude disabled placements", async () => {
+      const publicSettingsResponse = await fetch(
+        `${STOREFRONT_URL}/api/settings/public`,
+      );
+
+      if (
+        skipIfNoTenant(
+          publicSettingsResponse,
+          "ssr-storefront-content-zones-disabled-placements",
+        )
+      ) {
+        return;
+      }
+
+      expect(publicSettingsResponse.status).toBe(200);
+
+      const publicSettingsBody = await readJsonBody(publicSettingsResponse);
+      const publicData =
+        typeof publicSettingsBody?.data === "object" &&
+        publicSettingsBody.data !== null
+          ? (publicSettingsBody.data as Record<string, unknown>)
+          : null;
+      const storefrontContentBlocksRaw = publicData?.storefrontContentBlocks;
+      const storefrontContentBlocks =
+        typeof storefrontContentBlocksRaw === "object" &&
+        storefrontContentBlocksRaw !== null
+          ? (storefrontContentBlocksRaw as Record<string, unknown>)
+          : null;
+
+      if (!storefrontContentBlocks) {
+        log(
+          "ssr-storefront-content-zones-disabled-placements",
+          "WARN",
+          "storefrontContentBlocks ontbreekt in public settings; disabled-check overgeslagen",
+          "Deploy storefront blocks public settings contract op deze omgeving",
+          "HIGH",
+        );
+        return;
+      }
+
+      type BlockSurface = "home" | "product" | "category";
+      const rawPlacements = storefrontContentBlocks.placements;
+      const placements = Array.isArray(rawPlacements)
+        ? (rawPlacements as Array<Record<string, unknown>>)
+        : [];
+
+      const enabledSurfaceZone = new Set<string>();
+      const disabledZonesBySurface = new Map<BlockSurface, Set<string>>();
+      const toKey = (surface: string, zone: string): string =>
+        `${surface}::${zone}`;
+
+      for (const placement of placements) {
+        const surface = placement.surface;
+        const zone = placement.zone;
+        const enabled = placement.enabled;
+
+        if (
+          (surface === "home" ||
+            surface === "product" ||
+            surface === "category") &&
+          typeof zone === "string" &&
+          zone.trim().length > 0
+        ) {
+          const zoneValue = zone.trim();
+          if (enabled === false) {
+            const typedSurface = surface as BlockSurface;
+            const zones =
+              disabledZonesBySurface.get(typedSurface) ?? new Set<string>();
+            zones.add(zoneValue);
+            disabledZonesBySurface.set(typedSurface, zones);
+          } else {
+            enabledSurfaceZone.add(toKey(surface, zoneValue));
+          }
+        }
+      }
+
+      const effectiveDisabledZonesBySurface = new Map<
+        BlockSurface,
+        Set<string>
+      >();
+      for (const [surface, zones] of disabledZonesBySurface.entries()) {
+        const effectiveZones = new Set<string>();
+        for (const zone of zones) {
+          if (!enabledSurfaceZone.has(toKey(surface, zone))) {
+            effectiveZones.add(zone);
+          }
+        }
+        if (effectiveZones.size > 0) {
+          effectiveDisabledZonesBySurface.set(surface, effectiveZones);
+        }
+      }
+
+      if (effectiveDisabledZonesBySurface.size === 0) {
+        log(
+          "ssr-storefront-content-zones-disabled-placements",
+          "WARN",
+          "Geen exclusief disabled home/product/category placements gevonden; disabled-check overgeslagen",
+          "Voeg een placement toe met enabled=false zonder actieve tegenhanger",
+          "HIGH",
+        );
+        return;
+      }
+
+      const assertSsrZoneMarker = (
+        html: string,
+        surface: BlockSurface,
+        zone: string,
+      ): boolean => {
+        return (
+          html.includes('data-ssr-storefront-content-blocks="true"') &&
+          html.includes(`data-surface="${surface}"`) &&
+          html.includes(`data-zone="${zone}"`)
+        );
+      };
+
+      const htmlBySurface = new Map<BlockSurface, string>();
+
+      if (effectiveDisabledZonesBySurface.has("home")) {
+        const homeResponse = await fetch(STOREFRONT_URL);
+        if (homeResponse.status === 200) {
+          htmlBySurface.set("home", await homeResponse.text());
+        } else {
+          log(
+            "ssr-storefront-content-zones-disabled-home",
+            "WARN",
+            `Home niet beschikbaar voor disabled-check (HTTP ${homeResponse.status})`,
+            "Check storefront homepage route",
+            "HIGH",
+          );
+        }
+      }
+
+      if (effectiveDisabledZonesBySurface.has("category")) {
+        const categoriesResponse = await fetch(
+          `${STOREFRONT_URL}/api/categories`,
+        );
+        if (categoriesResponse.status === 200) {
+          const categoriesBody = await readJsonBody(categoriesResponse);
+          const categoriesRaw = categoriesBody?.data;
+          const categories = Array.isArray(categoriesRaw)
+            ? (categoriesRaw as Array<Record<string, unknown>>)
+            : [];
+          const sampleCategory = categories.find((entry) => {
+            if (
+              typeof entry.publicPath === "string" &&
+              entry.publicPath.trim()
+            ) {
+              return true;
+            }
+            if (typeof entry.slug === "string" && entry.slug.trim()) {
+              return true;
+            }
+            return false;
+          });
+          const categoryPath =
+            typeof sampleCategory?.publicPath === "string" &&
+            sampleCategory.publicPath.trim()
+              ? sampleCategory.publicPath
+              : typeof sampleCategory?.slug === "string" &&
+                  sampleCategory.slug.trim()
+                ? `/${sampleCategory.slug.trim()}`
+                : null;
+
+          if (!categoryPath) {
+            log(
+              "ssr-storefront-content-zones-disabled-category",
+              "WARN",
+              "Geen category pad beschikbaar voor disabled-check",
+              "Seed een actieve categorie met publicPath/slug",
+              "HIGH",
+            );
+          } else {
+            const categoryResponse = await fetch(
+              `${STOREFRONT_URL}${categoryPath}`,
+            );
+            if (categoryResponse.status === 200) {
+              htmlBySurface.set("category", await categoryResponse.text());
+            } else {
+              log(
+                "ssr-storefront-content-zones-disabled-category",
+                "WARN",
+                `Category niet beschikbaar voor disabled-check (HTTP ${categoryResponse.status})`,
+                "Check category route rendering",
+                "HIGH",
+              );
+            }
+          }
+        } else {
+          log(
+            "ssr-storefront-content-zones-disabled-category",
+            "WARN",
+            `Categories API niet beschikbaar voor disabled-check (HTTP ${categoriesResponse.status})`,
+            "Check /api/categories route",
+            "HIGH",
+          );
+        }
+      }
+
+      if (effectiveDisabledZonesBySurface.has("product")) {
+        const productsResponse = await fetch(
+          `${STOREFRONT_URL}/api/products?limit=1`,
+        );
+        if (productsResponse.status === 200) {
+          const productsBody = await readJsonBody(productsResponse);
+          const productsRaw = productsBody?.data;
+          const products = Array.isArray(productsRaw)
+            ? (productsRaw as Array<Record<string, unknown>>)
+            : [];
+          const sampleProduct = products.find(
+            (entry) =>
+              typeof entry.slug === "string" && entry.slug.trim().length > 0,
+          );
+
+          const productSlug =
+            typeof sampleProduct?.slug === "string"
+              ? sampleProduct.slug.trim().replace(/^\/+/, "")
+              : "";
+          const primaryCategoryPublicPath =
+            typeof sampleProduct?.primaryCategoryPublicPath === "string" &&
+            sampleProduct.primaryCategoryPublicPath.trim()
+              ? sampleProduct.primaryCategoryPublicPath.replace(/\/+$/, "")
+              : "";
+          const productPath = productSlug
+            ? primaryCategoryPublicPath
+              ? `${primaryCategoryPublicPath}/${productSlug}`
+              : `/${productSlug}`
+            : null;
+
+          if (!productPath) {
+            log(
+              "ssr-storefront-content-zones-disabled-product",
+              "WARN",
+              "Geen product pad beschikbaar voor disabled-check",
+              "Seed een actief product met slug",
+              "HIGH",
+            );
+          } else {
+            const productResponse = await fetch(
+              `${STOREFRONT_URL}${productPath}`,
+            );
+            if (productResponse.status === 200) {
+              htmlBySurface.set("product", await productResponse.text());
+            } else {
+              log(
+                "ssr-storefront-content-zones-disabled-product",
+                "WARN",
+                `Product niet beschikbaar voor disabled-check (HTTP ${productResponse.status})`,
+                "Check product route rendering",
+                "HIGH",
+              );
+            }
+          }
+        } else {
+          log(
+            "ssr-storefront-content-zones-disabled-product",
+            "WARN",
+            `Products API niet beschikbaar voor disabled-check (HTTP ${productsResponse.status})`,
+            "Check /api/products route",
+            "HIGH",
+          );
+        }
+      }
+
+      let assertedSurfaces = 0;
+      for (const [
+        surface,
+        zones,
+      ] of effectiveDisabledZonesBySurface.entries()) {
+        const html = htmlBySurface.get(surface);
+        if (!html) {
+          continue;
+        }
+
+        const unexpectedZones = [...zones].filter((zone) =>
+          assertSsrZoneMarker(html, surface, zone),
+        );
+
+        if (unexpectedZones.length === 0) {
+          log(
+            `ssr-storefront-content-zones-disabled-${surface}`,
+            "PASS",
+            `Disabled zones niet gerenderd (${[...zones].join(", ")})`,
+          );
+        } else {
+          log(
+            `ssr-storefront-content-zones-disabled-${surface}`,
+            "FAIL",
+            `Disabled zones toch gerenderd (${unexpectedZones.join(", ")})`,
+            "Check storefront block filtering op enabled=false",
+            "HIGH",
+          );
+        }
+
+        expect(unexpectedZones).toHaveLength(0);
+        assertedSurfaces += 1;
+      }
+
+      if (assertedSurfaces === 0) {
+        log(
+          "ssr-storefront-content-zones-disabled-placements",
+          "WARN",
+          "Disabled placements gevonden maar geen surface kon geverifieerd worden op deze omgeving",
+          "Controleer of home/category/product voorbeeldroutes data teruggeven",
+          "HIGH",
+        );
+      }
+    });
+
     it("Products page serves HTML", async () => {
       const response = await fetch(`${STOREFRONT_URL}/products`);
 

--- a/tests/smoke/storefront.test.ts
+++ b/tests/smoke/storefront.test.ts
@@ -503,7 +503,9 @@ describe("Storefront Service - Smoke Tests", () => {
           hasValidShape
             ? "Publieke blog API geeft posts + pagination"
             : "Response mist posts/pagination shape",
-          hasValidShape ? undefined : "Controleer public-blog.routes.ts response shape",
+          hasValidShape
+            ? undefined
+            : "Controleer public-blog.routes.ts response shape",
           hasValidShape ? undefined : "HIGH",
         );
         expect(hasValidShape).toBe(true);
@@ -742,7 +744,11 @@ describe("Storefront Service - Smoke Tests", () => {
           !html.includes("contact-title");
 
         if (hasAlignedMarkup) {
-          log("contact-page", "PASS", "Contact markup + design stylesheet contract OK");
+          log(
+            "contact-page",
+            "PASS",
+            "Contact markup + design stylesheet contract OK",
+          );
         } else {
           log(
             "contact-page",
@@ -1550,6 +1556,46 @@ describe("Storefront Service - Smoke Tests", () => {
           "FAIL",
           `Server error: HTTP ${response.status}`,
           "Check /api/internal/google-drive/sync/scheduled auth middleware",
+          "HIGH",
+        );
+      }
+
+      expect(response.status).toBe(401);
+    });
+
+    it("POST /api/internal/payments/status fail-closed zonder trusted caller", async () => {
+      const response = await fetch(
+        `${STOREFRONT_URL}/api/internal/payments/status`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "CF-Worker": "smoke-maintenance-untrusted",
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      if (response.status === 401) {
+        log(
+          "internal-payments-caller-boundary",
+          "PASS",
+          "Internal payments endpoint blijft fail-closed zonder trusted caller",
+        );
+      } else if (response.status >= 500) {
+        log(
+          "internal-payments-caller-boundary",
+          "FAIL",
+          `Server error: HTTP ${response.status}`,
+          "Check /api/internal/payments/status internal auth middleware",
+          "HIGH",
+        );
+      } else {
+        log(
+          "internal-payments-caller-boundary",
+          "FAIL",
+          `Onverwachte status: HTTP ${response.status}`,
+          "Check /api/internal/payments/status internal auth middleware",
           "HIGH",
         );
       }

--- a/tests/smoke/storefront.test.ts
+++ b/tests/smoke/storefront.test.ts
@@ -475,6 +475,51 @@ describe("Storefront Service - Smoke Tests", () => {
       expect(response.status).toBe(200);
     });
 
+    it("Public blog API returns first-paint payload", async () => {
+      const response = await fetch(`${STOREFRONT_URL}/api/blog?page=1&limit=1`);
+
+      if (skipIfNoTenant(response, "public-blog-api")) return;
+      if (response.status === 404) {
+        log(
+          "public-blog-api",
+          "WARN",
+          "Publieke blog API nog niet gedeployed op deze smoke target",
+        );
+        return;
+      }
+
+      if (response.status === 200) {
+        const body = await readJsonBody(response);
+        const data = body?.data;
+        const hasValidShape =
+          typeof data === "object" &&
+          data !== null &&
+          Array.isArray((data as { posts?: unknown }).posts) &&
+          typeof (data as { pagination?: { page?: unknown } }).pagination
+            ?.page === "number";
+        log(
+          "public-blog-api",
+          hasValidShape ? "PASS" : "FAIL",
+          hasValidShape
+            ? "Publieke blog API geeft posts + pagination"
+            : "Response mist posts/pagination shape",
+          hasValidShape ? undefined : "Controleer public-blog.routes.ts response shape",
+          hasValidShape ? undefined : "HIGH",
+        );
+        expect(hasValidShape).toBe(true);
+      } else {
+        log(
+          "public-blog-api",
+          "FAIL",
+          `HTTP ${response.status}`,
+          "Check public-blog.routes.ts route mount en tenant blog schema",
+          "HIGH",
+        );
+      }
+
+      expect(response.status).toBe(200);
+    });
+
     it("Categories API returns data", async () => {
       const response = await fetch(`${STOREFRONT_URL}/api/categories`);
 
@@ -770,6 +815,38 @@ describe("Storefront Service - Smoke Tests", () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toContain("text/html");
+    });
+
+    it("Blog overview page serves SSR HTML", async () => {
+      const response = await fetch(`${STOREFRONT_URL}/blog`);
+
+      if (skipIfNoTenant(response, "blog-page")) return;
+      if (response.status === 404) {
+        log(
+          "blog-page",
+          "WARN",
+          "Blog overview route nog niet gedeployed op deze smoke target",
+        );
+        return;
+      }
+
+      const body = await response.text();
+      const hasBlogSsrPayload = body.includes("window.__BLOG_LIST__");
+      if (response.status === 200 && hasBlogSsrPayload) {
+        log("blog-page", "PASS", "Blog overview HTML contains SSR payload");
+      } else {
+        log(
+          "blog-page",
+          "FAIL",
+          `HTTP ${response.status}, SSR payload: ${hasBlogSsrPayload}`,
+          "Check page.routes.ts /blog route en renderBlogListPage",
+          "HIGH",
+        );
+      }
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/html");
+      expect(hasBlogSsrPayload).toBe(true);
     });
 
     it("Public pages API returns 200 for unknown tag filter", async () => {


### PR DESCRIPTION
## What
- replace hardcoded local cwd in `tests/quality/cloudflare-token-expiry.test.ts` with `process.cwd()`
- keep test behavior unchanged while making CLI execution path valid on GitHub runners

## Why
Scheduled **Platform Smoke Tests** were failing before smoke execution because the quality test spawned Node with a non-existent local path on CI runners.

## Result
- token-expiry quality test now runs with repo-root cwd in CI
- branch stack-check remains green
